### PR TITLE
Add try block to avoid crashing when .ico isn't available.

### DIFF
--- a/sgtk-menu/menu.py
+++ b/sgtk-menu/menu.py
@@ -699,8 +699,11 @@ class DesktopMenuItem(Gtk.MenuItem):
         image = None
         if icon_name:
             if icon_name.startswith('/'):
-                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_name, args.s, args.s)
-                image = Gtk.Image.new_from_pixbuf(pixbuf)
+                try:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_name, args.s, args.s)
+                    image = Gtk.Image.new_from_pixbuf(pixbuf)
+                except:
+                    pass
             else:
                 try:
                     if icon_name.endswith('.svg') or icon_name.endswith('.png'):


### PR DESCRIPTION
Add a try block, keeping in with the style of other parts of the code.

Fixes #9 