### PR TITLE
some fixes to floating WMs support

### DIFF
--- a/examples/appendices/appendix-ob
+++ b/examples/appendices/appendix-ob
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Reload",
+    "exec": "openbox --restart",
+    "icon": "openbox"
+  },
+  {
+    "name": "Logout",
+    "exec": "openbox --exit",
+    "icon": "exit"
+  },
+  {
+    "name": "Reboot",
+    "exec": "systemctl reboot",
+    "icon": "reload"
+  },
+  {
+    "name": "Shutdown",
+    "exec": "systemctl -i poweroff",
+    "icon": "window-close"
+  }
+]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='sgtk-menu',
-    version='0.5.0',
+    version='0.5.1',
     description='GTK menu for sway and i3',
     packages=['sgtk-menu'],
     include_package_data=True,

--- a/sgtk-menu/menu.py
+++ b/sgtk-menu/menu.py
@@ -124,7 +124,7 @@ def main():
         sys.exit(0)
 
     global appendix_file
-    parser = argparse.ArgumentParser(description="GTK menu for sway and i3")
+    parser = argparse.ArgumentParser(description="GTK menu for sway, i3 and some floating WMs")
     placement = parser.add_mutually_exclusive_group()
     placement.add_argument("-b", "--bottom", action="store_true", help="display menu at the bottom (sway & i3 only)")
     placement.add_argument("-c", "--center", action="store_true", help="center menu on the screen (sway & i3 only)")
@@ -141,11 +141,11 @@ def main():
     parser.add_argument("-n", "--no-menu", action="store_true", help="skip menu, display appendix only")
     parser.add_argument("-l", type=str, help="force language (e.g. \"de\" for German)")
     parser.add_argument("-s", type=int, default=20, help="menu icon size (min: 16, max: 48, default: 20)")
-    parser.add_argument("-w", type=int, help="menu width in px (integer, default: screen width / 8)")
-    parser.add_argument("-d", type=int, default=100, help="menu delay in milliseconds (default: 100)")
-    parser.add_argument("-o", type=float, default=0.3, help="overlay opacity (min: 0.0, max: 1.0, default: 0.3)")
+    parser.add_argument("-w", type=int, help="menu width in px (integer, default: screen width / 8")
+    parser.add_argument("-d", type=int, default=100, help="menu delay in milliseconds (default: 100; sway & i3 only)")
+    parser.add_argument("-o", type=float, default=0.3, help="overlay opacity (min: 0.0, max: 1.0, default: 0.3; sway & i3 only)")
     parser.add_argument("-t", type=int, default=30, help="sway submenu lines limit (default: 30)")
-    parser.add_argument("-y", type=int, default=0, help="y offset from edge to display menu at")
+    parser.add_argument("-y", type=int, default=0, help="y offset from edge to display menu at (sway & i3 only)")
     global args
     args = parser.parse_args()
     if args.s < 16:

--- a/sgtk-menu/menu.py
+++ b/sgtk-menu/menu.py
@@ -126,10 +126,8 @@ def main():
     global appendix_file
     parser = argparse.ArgumentParser(description="GTK menu for sway and i3")
     placement = parser.add_mutually_exclusive_group()
-    placement.add_argument("-b", "--bottom", action="store_true", help="display menu at the bottom")
-    placement.add_argument("-c", "--center", action="store_true", help="center menu on the screen")
-    placement.add_argument("-m", "--mouse", action="store_true",
-                           help="display at mouse pointer (floating WMs only, requires optional python-pynput package)")
+    placement.add_argument("-b", "--bottom", action="store_true", help="display menu at the bottom (sway & i3 only)")
+    placement.add_argument("-c", "--center", action="store_true", help="center menu on the screen (sway & i3 only)")
 
     favourites = parser.add_mutually_exclusive_group()
     favourites.add_argument("-f", "--favourites", action="store_true", help="prepend 5 most used items")
@@ -232,25 +230,15 @@ def main():
         win.resize(w, h)
     else:
         win.resize(1, 1)
-
-    if other_wm:
-        win.set_gravity(Gdk.Gravity.STATIC)
+        win.set_gravity(Gdk.Gravity.CENTER)
         win.set_resizable(False)
-        win.set_titlebar(None)
-        win.set_icon(None)
-        if args.mouse:
-            if pynput:
-                x, y = mouse_pointer.position
-                win.move(x, y)
-            else:
-                win.set_position(Gtk.WindowPosition.CENTER)
-                print("\nYou need the python-pynput package!\n")
-        elif args.center:
-            win.set_position(Gtk.WindowPosition.CENTER)
-        elif args.bottom:
-            win.move(x, h)
+        win.set_decorated(False)
+        if pynput:
+            x, y = mouse_pointer.position
+            win.move(x, y)
         else:
-            win.move(x, 0)
+            win.move(0, 0)
+            print("\nYou need the python-pynput package!\n")
 
     win.set_skip_taskbar_hint(True)
     win.menu = build_menu()


### PR DESCRIPTION
As I actually only use a single floating window manager, which is Openbox, I decided not to support the others, at least at the moment. If neither sway nor i3 detected, the positioning arguments will be omitted: the menu is expected to appear at the mouse pointer position, as the Openbox menu does.