### PR TITLE
Set window type to popup

### DIFF
--- a/sgtk_menu/menu.py
+++ b/sgtk_menu/menu.py
@@ -32,14 +32,6 @@ from sgtk_menu.tools import (
 
 wm = check_wm()
 
-# Will apply to the overlay window; we can't do so outside the config file on i3.
-# We'll do it for i3 by applying commands to the focused window in open_menu method.
-if wm == "sway":
-    var = subprocess.run(['swaymsg', 'for_window', '[title=\"~sgtk*\"]', 'floating', 'enable'],
-                         stdout=subprocess.DEVNULL).returncode == 0
-    var = subprocess.run(['swaymsg', 'for_window', '[title=\"~sgtk*\"]', 'border', 'none'],
-                         stdout=subprocess.DEVNULL).returncode == 0
-
 other_wm = not wm == "sway" and not wm == "i3"
 
 try:
@@ -258,10 +250,6 @@ def main():
             x = x + 1
             y = y + args.y
 
-        # Workaround to odd screen coordinates on dwm w/ multi-headed setup
-        if wm in ["dwm", "yaxwm"] and x > w:
-            x -= w
-
         win.move(x, y)
 
     win.set_skip_taskbar_hint(True)
@@ -287,7 +275,7 @@ def main():
 
 class MainWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self)
+        Gtk.Window.__init__(self, type=Gtk.WindowType.POPUP)
         self.set_title('~sgtk-menu')
         self.set_role('~sgtk-menu')
         self.connect("destroy", Gtk.main_quit)
@@ -447,11 +435,6 @@ class MainWindow(Gtk.Window):
 
 
 def open_menu():
-    if wm == "i3":
-        # we couldn't do this on i3 at the script start
-        subprocess.run(['i3-msg', 'floating', 'enable'], stdout=subprocess.DEVNULL)
-        subprocess.run(['i3-msg', 'border', 'none'], stdout=subprocess.DEVNULL)
-
     if args.bottom:
         gravity_widget = Gdk.Gravity.NORTH
         gravity_menu = Gdk.Gravity.SOUTH


### PR DESCRIPTION
Setting the window type in this way sets the override redirect flag and lets window managers ignore it.

Briefly tested on ob, i3, and yax. I did try sway but it was not right *(I think it's my setup)* so I'll leave that one up to you to test.

Feel free to just take what's here and close it, I know some of my changes might not be desirable.

Cheers