### PR TITLE
Bugfix: Crash, when no active window

### DIFF
--- a/sgtk_menu/tools.py
+++ b/sgtk_menu/tools.py
@@ -107,9 +107,12 @@ def display_geometry(win, wm, mouse_pointer):
             if mouse_pointer:
                 x, y = mouse_pointer.position
                 display_number = screen.get_monitor_at_point(x, y)
-            else:
+            elif screen.get_active_window():
                 # If pynput missing, the bar will always appear at top left corner of the screen w/ active window.
                 display_number = screen.get_monitor_at_window(screen.get_active_window())
+            else:
+                # Could not detect active window; use first monitor
+                display_number = 0
             rectangle = screen.get_monitor_geometry(display_number)
             return rectangle.x, rectangle.y, rectangle.width, rectangle.height
         except:


### PR DESCRIPTION
I encountered a bug, where the programm crashes, when there is no other window currently open.
When there is no other window open, the `screen.get_active_window()` function returns `None`, which leads to an exception in `screen.get_monitor_at_window()` function.
Therefor the `display_geometry()` function always returns `(0,0,0,0)`, which keeps the programm in the loop, where it waits for another result from the `display_geometry()` function, that will never come.
This will eventually lead to a crash (exit) in the main program, when there are to many retries.

The comments indicate to me, that the retries are necessary to wait for the `MainWindow` to appear. At least in my case (I use `bspwm` as a window manager, if this is relevant) the window will only appear, when the `win.show_all()` function is called, which is placed after the loop. Therefor the window will never appear at the time of the loop, which makes the retries technically unnecessary?

This bug can be fixed, by installing `pynput`, but I think then the dependency should not be marked as optional and also explicitly mentioned in the wiki.

Anyway, my solution was to include a default case, where we simply use the first available monitor, if no other active window is found. I think this is a very sensible default case.